### PR TITLE
Add DHID and DLID

### DIFF
--- a/packages/dvbjs/package.json
+++ b/packages/dvbjs/package.json
@@ -57,6 +57,11 @@
     {
       "name": "Adwirawien",
       "url": "https://github.com/Adwirawien"
+    },
+    {
+      "name": "Francis Doege",
+      "email": "hello@francisdoege.com",
+      "url": "https://github.com/justusjonas74"
     }
   ],
   "files": [

--- a/packages/dvbjs/src/interfaces.ts
+++ b/packages/dvbjs/src/interfaces.ts
@@ -98,6 +98,7 @@ export interface IStop extends ILocation {
   platform?: IPlatform;
   arrival: Date;
   departure: Date;
+  dhid: string;
 }
 
 export interface IStopLocation extends ILocation {
@@ -114,6 +115,7 @@ export interface INode {
   line: string;
   direction: string;
   diva?: IDiva;
+  dlid?: string;
   duration: number;
   path: coord[];
 }

--- a/packages/dvbjs/src/utils.ts
+++ b/packages/dvbjs/src/utils.ts
@@ -410,6 +410,7 @@ export function parsePoiID(id: string): { id: string; type: POI_TYPE } {
 function extractStop(stop: any): IStop {
   return {
     id: stop.DataId,
+    dhid: stop.DhId,
     name: stop.Name.trim(),
     city: stop.Place,
     type: stop.Type,
@@ -461,6 +462,7 @@ function extractNode(node: any, mapData: any): INode {
     line: node.Mot.Name ? node.Mot.Name : "",
     direction: node.Mot.Direction ? node.Mot.Direction.trim() : "",
     diva: parseDiva(node.Mot.Diva),
+    dlid: node.Mot.DlId,
     duration: node.Duration || 1,
     path: convertCoordinates(mapData[node.MapDataIndex]),
   };

--- a/packages/dvbjs/test/index.spec.ts
+++ b/packages/dvbjs/test/index.spec.ts
@@ -187,9 +187,9 @@ describe("dvb.route", () => {
     });
   });
 
-  describe('dvb.route "0 -> 0"', () => {
+  describe('dvb.route "33000016 -> 33000016"', () => {
     it("should reject too close routes", () =>
-      assert.isRejected(dvb.route("0", "0"), "origin too close to destination"));
+      assert.isRejected(dvb.route("33000016", "33000016"), "origin too close to destination"));
   });
 });
 
@@ -211,7 +211,7 @@ describe("dvb.findStop", () => {
 
     it("should find the correct exact stop", () =>
       dvb.findStop("Postplatz (Am Zwingerteich)").then((data) => {
-        assert.strictEqual("Postplatz (Am Zwingerteich)", data[0].name);
+        assert.strictEqual("Postplatz (Am Zwingert.)", data[0].name);
       }));
   });
 
@@ -424,7 +424,7 @@ describe("dvb.findAddress", () => {
     it("should resolve into an object with city, address and coords properties", () =>
       dvb.findAddress(lng, lat).then((address) => {
         assert.isDefined(address);
-        assert.strictEqual(address!.name, "Nöthnitzer Straße 44");
+        assert.strictEqual(address!.name, "Nöthnitzer Straße 44a");
         assert.strictEqual(address!.city, "Dresden");
         assert.strictEqual(address!.type, dvb.POI_TYPE.Coords);
         assert.approximately(address!.coords[0], lng, 0.001);

--- a/packages/dvbjs/test/index.spec.ts
+++ b/packages/dvbjs/test/index.spec.ts
@@ -1,7 +1,7 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 
 import axios from "axios";
-import chai, { assert } from "chai";
+import chai, { assert, expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import * as dvb from "../src/index";
 import { IRoute, IStop } from "../src/index";
@@ -113,7 +113,37 @@ describe("dvb.route", () => {
         assert.notEqual(0, durationSum);
       });
     });
+
+    it("all stops should have all prperties", ()=>{
+      const stops = data.trips.flatMap((trip)=>{
+        return trip.nodes.flatMap((node) => {
+          return node.stops
+        })
+      })
+      stops.forEach(stop => {
+        assert.property(stop,'id')
+        assert.property(stop,'dhid')
+        assert.property(stop,'name')
+        assert.property(stop,'city')
+        assert.property(stop,'type')
+        assert.property(stop,'platform')
+        assert.property(stop,'coords')
+        assert.property(stop,'arrival')
+        assert.property(stop,'departure')
+        expect(stop.dhid).not.to.be.empty
+      })
+    })
+
+    it("all nodes except footpaths should have prperty 'dlid' ", ()=>{
+      const nodes = data.trips.flatMap((trip)=>{
+        return trip.nodes
+      }).filter(node => node.mode && node.mode.name !== 'Footpath')
+      nodes.forEach(node=>{
+        expect(node.dlid).to.exist.and.to.be.an('string')
+      })
+    })
   });
+
   describe('dvb.route "33000742 (Helmholtzstraße) --> via: 33000016 (Bahnhof Neustadt) --> 33000037 (Postplatz Dresden)"', () => {
     let data: dvb.IRoute;
 

--- a/packages/dvbjs/test/index.spec.ts
+++ b/packages/dvbjs/test/index.spec.ts
@@ -114,31 +114,31 @@ describe("dvb.route", () => {
       });
     });
 
-    it("all stops should have all prperties", ()=>{
-      const stops = data.trips.flatMap((trip)=>{
+    it("all stops should have all prperties", () => {
+      const stops = data.trips.flatMap((trip) => {
         return trip.nodes.flatMap((node) => {
           return node.stops
         })
       })
       stops.forEach(stop => {
-        assert.property(stop,'id')
-        assert.property(stop,'dhid')
-        assert.property(stop,'name')
-        assert.property(stop,'city')
-        assert.property(stop,'type')
-        assert.property(stop,'platform')
-        assert.property(stop,'coords')
-        assert.property(stop,'arrival')
-        assert.property(stop,'departure')
+        assert.property(stop, 'id')
+        assert.property(stop, 'dhid')
+        assert.property(stop, 'name')
+        assert.property(stop, 'city')
+        assert.property(stop, 'type')
+        assert.property(stop, 'platform')
+        assert.property(stop, 'coords')
+        assert.property(stop, 'arrival')
+        assert.property(stop, 'departure')
         expect(stop.dhid).not.to.be.empty
       })
     })
 
-    it("all nodes except footpaths should have prperty 'dlid' ", ()=>{
-      const nodes = data.trips.flatMap((trip)=>{
+    it("all nodes except footpaths should have prperty 'dlid' ", () => {
+      const nodes = data.trips.flatMap((trip) => {
         return trip.nodes
       }).filter(node => node.mode && node.mode.name !== 'Footpath')
-      nodes.forEach(node=>{
+      nodes.forEach(node => {
         expect(node.dlid).to.exist.and.to.be.an('string')
       })
     })
@@ -164,22 +164,12 @@ describe("dvb.route", () => {
         route: IRoute,
         stopId: string
       ): IStop[][] => {
-        const filteredTrips: IStop[][] = [];
-        route.trips.forEach((trip) => {
-          const stopsPerTrip: IStop[] = [];
-          trip.nodes.forEach((node) => {
-            const filteredStops = node.stops.find((stop) => {
-              return stop.id === stopId;
-            });
-            if (filteredStops) {
-              stopsPerTrip.push(filteredStops);
-            }
-          });
-          filteredTrips.push(stopsPerTrip);
-        });
-        return filteredTrips;
-      };
-
+        return route.trips.map(trip => {
+          return trip.nodes.flatMap(node => {
+            return node.stops.filter(stop => stop.id == stopId)
+          })
+        })
+      }
       getStopsFromTripByID(data, "33000016").forEach((filteredTripByID) => {
         assert.isNotEmpty(filteredTripByID);
       });


### PR DESCRIPTION
- Added new property `dlid` to `INode` [(3759b48)](https://github.com/offenesdresden/dvbjs/commit/3759b48ca6d6bf5cfe75a424c7243a7a90bc8754)
- Added new property `dhid` to `IStop`  [(3759b48)](https://github.com/offenesdresden/dvbjs/commit/3759b48ca6d6bf5cfe75a424c7243a7a90bc8754)
- Changed some tests due to API changes [(e84cc7a)](https://github.com/offenesdresden/dvbjs/commit/e84cc7a05af90bb45df491ce1f88e73a60ac5d9e)
- Rewrote a my own test [(1030a1c)](https://github.com/offenesdresden/dvbjs/commit/1030a1cad4b14f1ce297a76b26e486149421e011)
- Added a new contributor 🙋‍♂️   [(8a234a1)](https://github.com/offenesdresden/dvbjs/commit/8a234a14f0935c22c673c79a9b2e7c26e5389669)

More information:
* [Wikipedia: DHID](https://de.wikipedia.org/wiki/Haltestelle#Datenhaltung:_DELFI,_zHV,_DHID,_Global_ID_und_IFOPT)
* The DLID uniquely identifies a public transport line in all German timetable systems